### PR TITLE
fix(public): scrub private org refs and reconcile identity

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,10 +12,10 @@
 ## Commands
 ```bash
 # Search git history (semantic)
-node ~/code/cirrus/DevOps/Memex/scripts/neural-memory.js search "your question"
+node scripts/neural-memory.js search "your question"
 
 # Save session note
-~/code/cirrus/DevOps/Memex/scripts/remember "what you did" --topics tag1,tag2
+node scripts/remember.js "what you did" --topics tag1,tag2
 ```
 
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ graph-memex.html
 
 # Claude Code session locks
 .claude/*.lock
+.claude/settings.local.json
 
 # Schemas (generated from source)
 schemas/session.schema.msgpack

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "memex": {
       "command": "node",
-      "args": ["/Users/doceno/code/DarkForgeAI/Memex/scripts/mcp-server.mjs"]
+      "args": ["./scripts/mcp-server.mjs"]
     }
   }
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025-2026 TheBlackFactory
+Copyright (c) 2025-2026 TinyDarkForge
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/content/global/commit-standards.json
+++ b/content/global/commit-standards.json
@@ -2,7 +2,7 @@
   "$schema": "../../schemas/content.schema.json",
   "version": "2.0.0",
   "type": "global_standard",
-  "title": "Commit Standards - Cirrus Inc.",
+  "title": "Commit Standards - TinyDarkForge",
   "applies_to": "all_repos",
   "last_updated": "2025-11-30",
   "format": {

--- a/docs/internal/FRAMEWORK.md
+++ b/docs/internal/FRAMEWORK.md
@@ -1,4 +1,4 @@
-# TheDarkFactory Development Framework
+# TinyDarkForge Development Framework
 
 A complete, repeatable system for going from idea to shipped product.
 Built for a 2-person team that builds with AI coding assistants.
@@ -180,7 +180,7 @@ Run this for every new project:
 
 ```bash
 # Create repo
-gh repo create TheDarkFactory/<project-name> --private --clone
+gh repo create <your-org>/<project-name> --private --clone
 cd <project-name>
 
 # Initialize
@@ -191,21 +191,21 @@ echo "node_modules/\n.DS_Store\n.env\n*.db\n*.db-journal\ndist/\n.cache/" > .git
 mkdir -p .claude/commands .github/workflows docs scripts tests
 
 # Create SPEC
-cp ~/code/TheDarkFactory/Memex/docs/templates/SPEC-TEMPLATE.md SPEC.md
+cp ~/code/<your-org>/Memex/docs/templates/SPEC-TEMPLATE.md SPEC.md
 
 # Create CLAUDE.md (critical for AI workflow)
-cp ~/code/TheDarkFactory/Memex/docs/templates/CLAUDE-TEMPLATE.md .claude/CLAUDE.md
+cp ~/code/<your-org>/Memex/docs/templates/CLAUDE-TEMPLATE.md .claude/CLAUDE.md
 
 # Create CI
-cp ~/code/TheDarkFactory/Memex/docs/templates/ci-node.yml .github/workflows/ci.yml
+cp ~/code/<your-org>/Memex/docs/templates/ci-node.yml .github/workflows/ci.yml
 # OR for Python:
-# cp ~/code/TheDarkFactory/Memex/docs/templates/ci-python.yml .github/workflows/ci.yml
+# cp ~/code/<your-org>/Memex/docs/templates/ci-python.yml .github/workflows/ci.yml
 
 # Create README
-cp ~/code/TheDarkFactory/Memex/docs/templates/README-TEMPLATE.md README.md
+cp ~/code/<your-org>/Memex/docs/templates/README-TEMPLATE.md README.md
 
 # MCP config for Memex integration
-cp ~/code/TheDarkFactory/Memex/docs/templates/mcp-template.json .mcp.json
+cp ~/code/<your-org>/Memex/docs/templates/mcp-template.json .mcp.json
 
 # Initial commit
 git add -A
@@ -249,7 +249,7 @@ Apply these settings to every repo:
 
 ```bash
 # Enable branch protection on main
-gh api repos/TheDarkFactory/<project-name>/branches/main/protection \
+gh api repos/<your-org>/<project-name>/branches/main/protection \
   --method PUT \
   --field required_status_checks='{"strict":true,"contexts":["test"]}' \
   --field enforce_admins=false \
@@ -257,18 +257,18 @@ gh api repos/TheDarkFactory/<project-name>/branches/main/protection \
   --field restrictions=null
 
 # Enable issues
-gh repo edit TheDarkFactory/<project-name> --enable-issues
+gh repo edit <your-org>/<project-name> --enable-issues
 
 # Add standard labels
-gh label create "enhancement" --color "a2eeef" --repo TheDarkFactory/<project-name>
-gh label create "bug" --color "d73a4a" --repo TheDarkFactory/<project-name>
-gh label create "security" --color "e4e669" --repo TheDarkFactory/<project-name>
-gh label create "documentation" --color "0075ca" --repo TheDarkFactory/<project-name>
-gh label create "testing" --color "bfd4f2" --repo TheDarkFactory/<project-name>
-gh label create "devops" --color "d4c5f9" --repo TheDarkFactory/<project-name>
-gh label create "ui" --color "f9d0c4" --repo TheDarkFactory/<project-name>
-gh label create "v1" --color "006b75" --repo TheDarkFactory/<project-name>
-gh label create "v2" --color "5319e7" --repo TheDarkFactory/<project-name>
+gh label create "enhancement" --color "a2eeef" --repo <your-org>/<project-name>
+gh label create "bug" --color "d73a4a" --repo <your-org>/<project-name>
+gh label create "security" --color "e4e669" --repo <your-org>/<project-name>
+gh label create "documentation" --color "0075ca" --repo <your-org>/<project-name>
+gh label create "testing" --color "bfd4f2" --repo <your-org>/<project-name>
+gh label create "devops" --color "d4c5f9" --repo <your-org>/<project-name>
+gh label create "ui" --color "f9d0c4" --repo <your-org>/<project-name>
+gh label create "v1" --color "006b75" --repo <your-org>/<project-name>
+gh label create "v2" --color "5319e7" --repo <your-org>/<project-name>
 ```
 
 ---
@@ -482,7 +482,7 @@ npx tsc --noEmit     # Type check
 
 ## Deep Queries
 ```bash
-node ~/code/TheDarkFactory/Memex/scripts/memex-loader.js quick "<query>"
+node ~/code/<your-org>/Memex/scripts/memex-loader.js quick "<query>"
 ```
 ```
 
@@ -509,12 +509,12 @@ Run the test suite and report results.
 ## Steps
 1. Run tests:
 ```bash
-cd /Users/doceno/code/TheDarkFactory/<project> && npm test 2>&1
+cd ~/code/<user>/<your-org>/<project> && npm test 2>&1
 ```
 
 2. If TypeScript project, also run type check:
 ```bash
-cd /Users/doceno/code/TheDarkFactory/<project> && npx tsc --noEmit 2>&1 | tail -30
+cd ~/code/<user>/<your-org>/<project> && npx tsc --noEmit 2>&1 | tail -30
 ```
 
 3. Report: total tests, passed, failed (with details).
@@ -560,7 +560,7 @@ Every project should have a `.mcp.json` that connects to Memex:
   "mcpServers": {
     "memex": {
       "command": "node",
-      "args": ["/Users/doceno/code/TheDarkFactory/Memex/scripts/mcp-server.mjs"]
+      "args": ["~/code/<user>/<your-org>/Memex/scripts/mcp-server.mjs"]
     }
   }
 }
@@ -578,12 +578,12 @@ This gives the AI assistant access to:
   "mcpServers": {
     "memex": {
       "command": "node",
-      "args": ["/Users/doceno/code/TheDarkFactory/Memex/scripts/mcp-server.mjs"]
+      "args": ["~/code/<user>/<your-org>/Memex/scripts/mcp-server.mjs"]
     },
     "agentbridge": {
       "command": "python",
       "args": ["-m", "agentbridge.mcp_server"],
-      "cwd": "/Users/doceno/code/TheDarkFactory/AgentBridge"
+      "cwd": "~/code/<user>/<your-org>/AgentBridge"
     }
   }
 }
@@ -594,7 +594,7 @@ This gives the AI assistant access to:
 At the end of every significant coding session, save what you did:
 
 ```bash
-~/code/TheDarkFactory/Memex/scripts/remember "what you accomplished" --topics tag1,tag2
+~/code/<your-org>/Memex/scripts/remember "what you accomplished" --topics tag1,tag2
 ```
 
 This feeds Memex and makes future AI sessions smarter. Do this especially for:
@@ -668,16 +668,16 @@ Use the same labels across all repos (created in Phase 3):
 
 ```bash
 # List current tasks
-gh issue list --repo TheDarkFactory/<project> --state open
+gh issue list --repo <your-org>/<project> --state open
 
 # Create a task
-gh issue create --repo TheDarkFactory/<project> \
+gh issue create --repo <your-org>/<project> \
   --title "feat(auth): add password reset" \
   --label "enhancement,v1" \
   --assignee Pamperito74
 
 # Close a task
-gh issue close <number> --repo TheDarkFactory/<project>
+gh issue close <number> --repo <your-org>/<project>
 ```
 
 ---
@@ -813,7 +813,7 @@ Every project must have:
 
 ## Appendix A: Templates
 
-All templates live in `/Users/doceno/code/TheDarkFactory/Memex/docs/templates/`.
+All templates live in `~/code/<user>/<your-org>/Memex/docs/templates/`.
 Copy them when scaffolding a new project.
 
 ### SPEC Template
@@ -860,7 +860,7 @@ npm run build        # Production build
 
 ## Deep Queries
 \`\`\`bash
-node ~/code/TheDarkFactory/Memex/scripts/memex-loader.js quick "<query>"
+node ~/code/<your-org>/Memex/scripts/memex-loader.js quick "<query>"
 \`\`\`
 ```
 
@@ -942,7 +942,7 @@ File: `docs/templates/mcp-template.json`
   "mcpServers": {
     "memex": {
       "command": "node",
-      "args": ["/Users/doceno/code/TheDarkFactory/Memex/scripts/mcp-server.mjs"]
+      "args": ["~/code/<user>/<your-org>/Memex/scripts/mcp-server.mjs"]
     }
   }
 }
@@ -952,7 +952,7 @@ File: `docs/templates/mcp-template.json`
 
 ## Appendix B: Stack Reference
 
-### TheDarkFactory Standard Stack (2026)
+### TinyDarkForge Standard Stack (2026)
 
 | Layer | Default Choice | When to Use Something Else |
 |-------|---------------|---------------------------|
@@ -1023,5 +1023,5 @@ The framework document you are reading IS the specification for that web app.
 
 ---
 
-*TheDarkFactory Development Framework v1.0 -- 2026-02-20*
+*TinyDarkForge Development Framework v1.0 -- 2026-02-20*
 *Built for humans who build with AI.*

--- a/docs/templates/mcp-template.json
+++ b/docs/templates/mcp-template.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "memex": {
       "command": "node",
-      "args": ["/Users/doceno/code/TheDarkFactory/Memex/scripts/mcp-server.mjs"]
+      "args": ["./scripts/mcp-server.mjs"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "context",
     "semantic-search"
   ],
-  "author": "TheBlackFactory",
+  "author": "TinyDarkForge",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/scripts/memex-loader.js
+++ b/scripts/memex-loader.js
@@ -192,7 +192,7 @@ class Memex {
       const pkgPath = path.join(cwd, 'package.json');
       const pkg = readJSON(pkgPath);
       if (pkg) {
-        const projectName = pkg.name?.replace('@cirrus/', '');
+        const projectName = pkg.name?.replace(/^@[^/]+\//, '');
         if (projectName && this.index.p[projectName]) {
           this.currentProject = projectName;
           return { method: 'package.json', project: projectName };

--- a/templates/.claude/MEMEX.md
+++ b/templates/.claude/MEMEX.md
@@ -10,7 +10,7 @@ On startup, Claude should run:
 
 ```javascript
 // Load Memex for this project
-const memex = require('~/code/cirrus/DevOps/Memex/scripts/memex-loader.js');
+const memex = require('~/code/<your-org>/Memex/scripts/memex-loader.js');
 const loader = new memex();
 const context = loader.startup();
 


### PR DESCRIPTION
## Summary

- `.mcp.json`, `docs/templates/mcp-template.json`: hardcoded `/Users/doceno` paths → `./scripts/mcp-server.mjs`
- `.claude/CLAUDE.md`, `templates/.claude/MEMEX.md`: remove `cirrus` org references, use generic placeholders
- `.gitignore`: add `settings.local.json` exclusion
- `content/global/commit-standards.json`: rebrand "Cirrus Inc." → "TinyDarkForge"
- `scripts/memex-loader.js:195`: strip hardcoded `@cirrus/` scope with generic regex
- `LICENSE`, `package.json`: `TheBlackFactory` → `TinyDarkForge`
- `docs/THEDARKFACTORY-FRAMEWORK.md`: moved to `docs/internal/FRAMEWORK.md`, all private paths scrubbed

Closes #24

## Test plan
- [ ] `.mcp.json` resolves with `node ./scripts/mcp-server.mjs`
- [ ] No `/Users/doceno`, `cirrus`, `TheBlackFactory`, or `DarkForgeAI` refs in tracked files
- [ ] `npm test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)