### PR TITLE
fix: support project CLI flag and seed initial project entry

### DIFF
--- a/scripts/save-session.js
+++ b/scripts/save-session.js
@@ -304,7 +304,10 @@ class SessionSaver {
       const sessionsIndex = readJSON(sessionsIndexPath);
       if (sessionsIndex) {
         // v2.0 uses abbreviated keys: p=projects, sc=session_count, u=last_updated
-        if (index.p && index.p[this.currentProject]) {
+        if (index.p) {
+          if (!index.p[this.currentProject]) {
+            index.p[this.currentProject] = { sc: 0, u: '' };
+          }
           index.p[this.currentProject].sc = sessionsIndex.total_sessions;
           index.p[this.currentProject].u = new Date().toISOString().split('T')[0];
         }
@@ -408,13 +411,16 @@ if (require.main === module) {
 
   (async () => {
     try {
-      const saver = new SessionSaver();
+      const projectIdx = args.indexOf('--project');
+      const project = projectIdx > -1 && args[projectIdx + 1] ? args[projectIdx + 1] : undefined;
+      const saver = new SessionSaver(project ? { project } : {});
 
       if (args.includes('--interactive') || args.length === 0) {
         await saver.interactive();
       } else {
         const autoSummarize = args.includes('--auto-summarize');
         const topicsIndex = args.indexOf('--topics');
+        const projectIndex = args.indexOf('--project');
         const commit = args.includes('--commit');
         const push = args.includes('--push');
 

--- a/summaries/projects/engram/sessions-index.json
+++ b/summaries/projects/engram/sessions-index.json
@@ -1,0 +1,83 @@
+{
+  "project": "engram",
+  "project_display": "engram",
+  "project_slug": "engram",
+  "total_sessions": 2,
+  "last_updated": "2026-05-22",
+  "sessions": [
+    {
+      "id": "en-2026-05-22-1545-engram-89d22a",
+      "project": "engram",
+      "project_display": "engram",
+      "project_slug": "engram",
+      "date": "2026-05-22",
+      "summary": "Second test — verified session persistence after save, checked query returns results",
+      "topics": [
+        "engram",
+        "testing",
+        "persistence"
+      ],
+      "key_decisions": [],
+      "outcomes": {
+        "completed": []
+      },
+      "learnings": [],
+      "code_changes": {
+        "files_added": [],
+        "files_modified": [
+          "scripts/save-session.js"
+        ],
+        "files_deleted": [],
+        "lines_added": 4,
+        "lines_removed": 1
+      }
+    },
+    {
+      "id": "en-2026-05-22-1545-engram-c2554a",
+      "project": "engram",
+      "project_display": "engram",
+      "project_slug": "engram",
+      "date": "2026-05-22",
+      "summary": "Tested Engram MCP integration with opencode — registered global MCP server, verified tools are available to AI agent, confirmed 0 lint errors across fixes",
+      "topics": [
+        "engram",
+        "mcp",
+        "opencode",
+        "testing"
+      ],
+      "key_decisions": [],
+      "outcomes": {
+        "completed": []
+      },
+      "learnings": [],
+      "code_changes": {
+        "files_added": [],
+        "files_modified": [
+          "scripts/save-session.js"
+        ],
+        "files_deleted": [],
+        "lines_added": 4,
+        "lines_removed": 1
+      }
+    }
+  ],
+  "topics_index": {
+    "engram": [
+      "en-2026-05-22-1545-engram-c2554a",
+      "en-2026-05-22-1545-engram-89d22a"
+    ],
+    "mcp": [
+      "en-2026-05-22-1545-engram-c2554a"
+    ],
+    "opencode": [
+      "en-2026-05-22-1545-engram-c2554a"
+    ],
+    "testing": [
+      "en-2026-05-22-1545-engram-c2554a",
+      "en-2026-05-22-1545-engram-89d22a"
+    ],
+    "persistence": [
+      "en-2026-05-22-1545-engram-89d22a"
+    ]
+  }
+}


### PR DESCRIPTION
Two fixes found during dogfooding:\n- **CLI**: `--project` flag was parsed but never passed to SessionSaver, making `save-session --project <name>` fail with "Could not detect current project"\n- **Index seeding**: `updateMainIndex` only updated existing project entries. Fresh installs start with an empty `p` object, so the first save never populated it. Now creates the entry if missing.